### PR TITLE
version bump, adds abilty to use sync and other options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,30 @@ elixir(function(mix) {
 
 });
 ```
+
+Pass in options that are available to `del()`
+```javascript
+var elixir = require('laravel-elixir');
+
+require('laravel-elixir-del');
+
+elixir(function(mix) {
+
+  mix.del('src/js/', {force: true, dryRun: true});
+
+});
+```
+
+In some cases it's better to just delete, and not return a promise to delete, you can do the following:
+```javascript
+var elixir = require('laravel-elixir');
+
+require('laravel-elixir-del');
+
+elixir(function(mix) {
+
+  mix.del('src/js/', {useSync: true});
+
+});
+```
+The `useSync` option will run `del.sync()` instead of `del()` meaning anything it deletes  all the files it finds immediately.

--- a/index.js
+++ b/index.js
@@ -3,8 +3,14 @@ var Elixir = require('laravel-elixir'),
 
 var Task = Elixir.Task;
 
-Elixir.extend('del', function (arr) {
+Elixir.extend('del', function (arr, options) {
+    options = (typeof options === "undefined") ? {} : options;
+
     new Task('del', function () {
-        return del(arr);
+        if (options.useSync) {
+            return del.sync(arr, options);
+        }
+
+        return del(arr, options);
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-elixir-del",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Delete files and folders in your Laravel project",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I kept running into this issue with `del()` because it was returning a promise. I needed a way to use `del.sync()` instead of just `del()`. Also, `del()` has a couple of options (like force) that could be useful to other people so I forked and modified your code a bit. Basically there's now an `options` param and if you send it `options.useSync` it just deletes everything instead of going down the whole Promise path. 